### PR TITLE
fix(posts): fix padding issue for large post content and overflowing code blocks

### DIFF
--- a/src/app/r/[slug]/post/[postId]/page.tsx
+++ b/src/app/r/[slug]/post/[postId]/page.tsx
@@ -62,7 +62,7 @@ const Page = async ({ params }: PageProps) => {
             />
           </Suspense>
           <div className="w-0 flex-1">
-            <div className="max-h-40 mt-1 text-xs text-gray-500">
+            <div className="mt-1 text-xs text-gray-500">
               <p className="max-h-40 mt-1 truncate text-xs text-gray-500">
                 Posted by{" "}
                 <a

--- a/src/components/ui/posts/EditorOutput.tsx
+++ b/src/components/ui/posts/EditorOutput.tsx
@@ -47,7 +47,7 @@ function CustomImageRenderer({ data }: any) {
 
 function CustomCodeRenderer({ data }: any) {
   return (
-    <pre className="bg-gray-800 rounded-md p-4">
+    <pre className="bg-gray-800 rounded-md p-4 overflow-auto">
       <code className="text-gray-100 text-sm">{data.code}</code>
     </pre>
   );


### PR DESCRIPTION
## Problem

Previously, post banner heights did not grow with large blocks of post content. Additionally, code blocks with long lines of code would clip the overflowing code.

## Solution

This PR solves this issue by removing a misplaced max height style. This PR also solves horizontally long code blocks by making them scrollable.

## Screenshots

### Padding Issue
![image](https://github.com/youngwoo206/Project_PulsePoint/assets/63864727/e33c4075-e133-410a-8a56-2b142e4ee1e4)

### Code Block Issue
![image](https://github.com/youngwoo206/Project_PulsePoint/assets/63864727/50548926-7bc4-4c89-9c77-49bd768a4299)

## References
[Notion Tasks](https://www.notion.so/BUG-padding-issue-for-large-blocks-of-code-and-images-b92a8ec994e34efe95026e5c2302b6)