### PR TITLE
fix(subreddit): fix invalid characters from being typed into the subreddit creation form

### DIFF
--- a/src/app/r/create/page.tsx
+++ b/src/app/r/create/page.tsx
@@ -76,7 +76,11 @@ const Page = () => {
             </p>
             <Input
               value={input}
-              onChange={(e) => setInput(e.target.value)}
+              onChange={(e) => {
+                e.target.value = e.target.value.replaceAll(/[^a-z0-9_]/gi, "");
+                setInput(e.target.value);
+              }}
+              maxLength={21}
               className="pl-6"
             />
           </div>


### PR DESCRIPTION
## Problem

Previously, users were able to type in spaces, special characters and hypens into the subreddit naming form. While this would still allow subreddits to be created, it will cause issues within routes due to the introduction of spaces in the route names.

## Solution

Add a regex replacement on form control to only allow alphanumeric + _ characters

## Testing Plan

1. Visit the Vercel preview link.
2. Try typing invalid characters into the subreddit creation form.
3. Verify that invalid characters are not registered.

## References
[Notion Tasks](https://www.notion.so/BUG-prevent-user-from-adding-space-to-subreddit-name-9afad8515f3a48d8b7fcad4052bfc438?pvs=4)